### PR TITLE
Fix SettingEntity id duplication

### DIFF
--- a/BankApp.Data/Entities/SettingEntity.cs
+++ b/BankApp.Data/Entities/SettingEntity.cs
@@ -8,8 +8,6 @@ namespace BankApp.Data.Entities
 {
     public class SettingEntity : BaseEntity
     {
-        public int Id { get; set; }
-
         public bool MaintenanceMode { get; set; }
     }// end of class SettingEntity
 }


### PR DESCRIPTION
## Summary
- Remove redundant Id declaration from `SettingEntity` to rely on `BaseEntity.Id`

## Testing
- `dotnet build BankApp.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b702d67d54832b892d12aab294ceac