### PR TITLE
Remove duplicate CreatedAt field from accounts

### DIFF
--- a/BankApp.Business/Operations/Account/AccountService.cs
+++ b/BankApp.Business/Operations/Account/AccountService.cs
@@ -72,7 +72,7 @@ namespace BankApp.Business.Operations.Account
                     AccountNumber = newAccount.AccountNumber,
                     Currency = newAccount.Currency,
                     Balance = newAccount.Balance,
-                    CreatedAt = newAccount.CreatedDate,
+                    CreatedDate = newAccount.CreatedDate,
                 }
             };
         } // end of AddAcountAsync
@@ -87,7 +87,7 @@ namespace BankApp.Business.Operations.Account
                                                 UserId = a.UserId,
                                                 AccountNumber = a.AccountNumber,
                                                 Currency = a.Currency,
-                                                CreatedAt = a.CreatedAt,
+                                                CreatedDate = a.CreatedDate,
                                                 Balance = a.Balance
 
                                             }).ToListAsync();

--- a/BankApp.Business/Operations/Account/Dtos/AccountInfoDto.cs
+++ b/BankApp.Business/Operations/Account/Dtos/AccountInfoDto.cs
@@ -13,6 +13,6 @@ namespace BankApp.Business.Operations.Account.Dtos
         public string AccountNumber { get; set; }
         public decimal Balance { get; set; }
         public string Currency { get; set; }
-        public DateTime CreatedAt { get; set; }
+        public DateTime CreatedDate { get; set; }
     }
 }

--- a/BankApp.Data/Entities/AccountEntity.cs
+++ b/BankApp.Data/Entities/AccountEntity.cs
@@ -14,7 +14,6 @@ namespace BankApp.Data.Entities
         public string AccountNumber { get; set; }
         public decimal Balance { get; set; }            // account balance
         public string Currency { get; set; }            // ( TRY, USD) a like
-        public DateTime CreatedAt { get; set; }
         public bool IsActive { get; set; }
 
         

--- a/BankApp.Data/Migrations/20250901000000_RemoveAccountCreatedAt.cs
+++ b/BankApp.Data/Migrations/20250901000000_RemoveAccountCreatedAt.cs
@@ -1,0 +1,31 @@
+using System;
+using BankApp.Data.Context;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BankApp.Data.Migrations
+{
+    [DbContext(typeof(BankAppDbContext))]
+    [Migration("20250901000000_RemoveAccountCreatedAt")]
+    public partial class RemoveAccountCreatedAt : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreatedAt",
+                table: "Accounts");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CreatedAt",
+                table: "Accounts",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+    }
+}
+

--- a/BankApp.Data/Migrations/BankAppDbContextModelSnapshot.cs
+++ b/BankApp.Data/Migrations/BankAppDbContextModelSnapshot.cs
@@ -39,9 +39,6 @@ namespace BankApp.Data.Migrations
                         .HasPrecision(18, 2)
                         .HasColumnType("decimal(18,2)");
 
-                    b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
-
                     b.Property<DateTime>("CreatedDate")
                         .HasColumnType("datetime2");
 


### PR DESCRIPTION
## Summary
- drop redundant CreatedAt from AccountEntity and rely on CreatedDate
- align AccountService and DTOs to use CreatedDate only
- add migration dropping CreatedAt column

## Testing
- `apt-get update`
- `dotnet build` *(fails: command not found)*
- `dotnet ef migrations list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b704799af0832ba973207de2341c69