### PR TITLE
Enforce user ownership when deleting accounts

### DIFF
--- a/BankApp.Business.Tests/AccountServiceTests.cs
+++ b/BankApp.Business.Tests/AccountServiceTests.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+using BankApp.Business.Operations.Account;
+using BankApp.Data.Entities;
+using BankApp.Data.Repositories;
+using BankApp.Data.UnitOfWork;
+using Moq;
+using Xunit;
+
+namespace BankApp.Business.Tests
+{
+    public class AccountServiceTests
+    {
+        [Fact]
+        public async Task DeleteAccountAsync_Should_Fail_When_UserIdDoesNotMatch()
+        {
+            var repository = new Mock<IRepository<AccountEntity>>();
+            var unitOfWork = new Mock<IUnitOfWork>();
+            var transactionRepository = new Mock<IRepository<MoneyTransactionEntity>>();
+            var userRepository = new Mock<IRepository<UserEntity>>();
+
+            repository.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(new AccountEntity { Id = 1, UserId = 1 });
+
+            var service = new AccountService(repository.Object, unitOfWork.Object, transactionRepository.Object, userRepository.Object);
+
+            var result = await service.DeleteAccountAsync(1, 2);
+
+            Assert.False(result.IsSuccess);
+            repository.Verify(r => r.DeleteAsync(It.IsAny<AccountEntity>()), Times.Never);
+        }
+    }
+}

--- a/BankApp.Business.Tests/BankApp.Business.Tests.csproj
+++ b/BankApp.Business.Tests/BankApp.Business.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="xunit" Version="2.7.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.10">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BankApp.Business\BankApp.Business.csproj" />
+    <ProjectReference Include="..\BankApp.Data\BankApp.Data.csproj" />
+  </ItemGroup>
+</Project>

--- a/BankApp.Business/Operations/Account/AccountService.cs
+++ b/BankApp.Business/Operations/Account/AccountService.cs
@@ -111,25 +111,25 @@ namespace BankApp.Business.Operations.Account
             };
         } // end of AllAccountAsync
 
-        public async Task<ServiceMessage> DeleteAccountAsync(int id) // method beginning
+        public async Task<ServiceMessage> DeleteAccountAsync(int id, int userId) // method beginning
         {
             var account = await _repository.GetByIdAsync(id);
-            if (account is null)
+            if (account is null || account.UserId != userId)
             {
-                return new ServiceMessage()
+                return new ServiceMessage
                 {
-                     IsSuccess = false,
-                     Message = "hesap bulunamadı"
+                    IsSuccess = false,
+                    Message = account is null ? "hesap bulunamadı" : "Bu hesaba erişiminiz yok"
                 };
             }
 
             await _repository.DeleteAsync(account);
             await _unitOfWork.SaveChangesAsync();
 
-            return new ServiceMessage()
+            return new ServiceMessage
             {
-                 IsSuccess = true,
-                 Message = "hesap başarıyla silindi"
+                IsSuccess = true,
+                Message = "hesap başarıyla silindi"
             };
         } // end of DeleteAccountAsync
 

--- a/BankApp.Business/Operations/Account/IAccountService.cs
+++ b/BankApp.Business/Operations/Account/IAccountService.cs
@@ -22,7 +22,7 @@ namespace BankApp.Business.Operations.Account
 
         Task<ServiceMessage<TransferResultDto>> DepositAsync(DepositRequestDto request);
 
-        Task<ServiceMessage> DeleteAccountAsync(int id);
+        Task<ServiceMessage> DeleteAccountAsync(int id, int userId);
 
 
     }

--- a/BankApp.WepApi/Controllers/V1/AccountsController.cs
+++ b/BankApp.WepApi/Controllers/V1/AccountsController.cs
@@ -198,9 +198,13 @@ namespace BankApp.WepApi.Controllers.V1
 
             }
 
-            var userIdStr = int.TryParse(User.FindFirstValue("id"),out int userId);
+            var userIdString = User.FindFirstValue("id");
+            if (!int.TryParse(userIdString, out int userId))
+            {
+                return Unauthorized("Kullanıcı doğrulanamadı");
+            }
 
-            var result = await _accountService.DeleteAccountAsync(id);
+            var result = await _accountService.DeleteAccountAsync(id, userId);
 
             if (!result.IsSuccess)
             {

--- a/BankApp.sln
+++ b/BankApp.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BankApp.Business", "BankApp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BankApp.WepApi", "BankApp.WepApi\BankApp.WepApi.csproj", "{82506871-7E26-4F9C-B647-56837C2C7E95}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BankApp.Business.Tests", "BankApp.Business.Tests\BankApp.Business.Tests.csproj", "{A9BCCFB2-937B-47F7-BCDA-255CAC905A8F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{82506871-7E26-4F9C-B647-56837C2C7E95}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{82506871-7E26-4F9C-B647-56837C2C7E95}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{82506871-7E26-4F9C-B647-56837C2C7E95}.Release|Any CPU.Build.0 = Release|Any CPU
+                {A9BCCFB2-937B-47F7-BCDA-255CAC905A8F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {A9BCCFB2-937B-47F7-BCDA-255CAC905A8F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {A9BCCFB2-937B-47F7-BCDA-255CAC905A8F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {A9BCCFB2-937B-47F7-BCDA-255CAC905A8F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- Verify account belongs to requesting user before deletion
- Return Unauthorized when user ID cannot be parsed
- Add unit test preventing unauthorized account deletions

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b70642bf68832ba28335893dd45155