### PR TITLE
Use StringLength for AddAccountRequest and add validation tests

### DIFF
--- a/BankApp.Business.Tests/AddAccountRequestValidationTests.cs
+++ b/BankApp.Business.Tests/AddAccountRequestValidationTests.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using BankApp.WepApi.Models;
+using Xunit;
+
+namespace BankApp.Business.Tests
+{
+    public class AddAccountRequestValidationTests
+    {
+        [Fact]
+        public void Currency_LengthGreaterThanThree_ShouldFailValidation()
+        {
+            var model = new AddAccountRequest { Currency = "USDT" };
+            var results = new List<ValidationResult>();
+
+            var isValid = Validator.TryValidateObject(model, new ValidationContext(model), results, true);
+
+            Assert.False(isValid);
+            Assert.Contains(results, r => r.MemberNames.Contains(nameof(AddAccountRequest.Currency)));
+        }
+
+        [Fact]
+        public void Currency_LengthWithinRange_ShouldPassValidation()
+        {
+            var model = new AddAccountRequest { Currency = "USD" };
+            var results = new List<ValidationResult>();
+
+            var isValid = Validator.TryValidateObject(model, new ValidationContext(model), results, true);
+
+            Assert.True(isValid);
+        }
+    }
+}

--- a/BankApp.Business.Tests/BankApp.Business.Tests.csproj
+++ b/BankApp.Business.Tests/BankApp.Business.Tests.csproj
@@ -17,5 +17,6 @@
   <ItemGroup>
     <ProjectReference Include="..\BankApp.Business\BankApp.Business.csproj" />
     <ProjectReference Include="..\BankApp.Data\BankApp.Data.csproj" />
+    <ProjectReference Include="..\BankApp.WepApi\BankApp.WepApi.csproj" />
   </ItemGroup>
 </Project>

--- a/BankApp.WepApi/Models/AddAccountRequest.cs
+++ b/BankApp.WepApi/Models/AddAccountRequest.cs
@@ -4,7 +4,7 @@ namespace BankApp.WepApi.Models
 {
     public class AddAccountRequest
     {
-        [Length(minimumLength:1,maximumLength:3)]
+        [StringLength(3, MinimumLength = 1)]
         [Required]
         public string Currency { get; set; }
     }


### PR DESCRIPTION
## Summary
- replace deprecated Length attribute with StringLength on AddAccountRequest's Currency
- add unit tests to verify Currency length validation and reference web API project from tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b70849d57c832baba7e901e5ba4a73