### PR TITLE
Fix helper namespace for sequential number validator

### DIFF
--- a/BankApp.WepApi/Helpers/SequentialNumberMethod.cs
+++ b/BankApp.WepApi/Helpers/SequentialNumberMethod.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace BankApp.WebApi.Helpers
+namespace BankApp.WepApi.Helpers
 {
     public static class SequentialNumberMethod // this class checks for sequential numbers in a string
     {

--- a/BankApp.WepApi/Validation/StrongPasswordAttribute.cs
+++ b/BankApp.WepApi/Validation/StrongPasswordAttribute.cs
@@ -1,5 +1,4 @@
-﻿using BankApp.WebApi.Helpers;
-using BankApp.WepApi.Helpers;
+﻿using BankApp.WepApi.Helpers;
 using System.ComponentModel.DataAnnotations;
 
 namespace BankApp.WepApi.Validation


### PR DESCRIPTION
## Summary
- fix SequentialNumberMethod namespace to BankApp.WepApi.Helpers
- update StrongPasswordAttribute using directives for new helper namespace

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b708539828832b94e1968e0860da7b