### PR TITLE
Rename password property to Password

### DIFF
--- a/BankApp.Business/Operations/User/Dtos/LoginRequestDto.cs
+++ b/BankApp.Business/Operations/User/Dtos/LoginRequestDto.cs
@@ -9,6 +9,6 @@ namespace BankApp.Business.Operations.User.Dtos
     public class LoginRequestDto
     {
         public string Email { get; set; }
-        public string password { get; set; }
+        public string Password { get; set; }
     }// end of loginRequestDto
 }

--- a/BankApp.Business/Operations/User/UserService.cs
+++ b/BankApp.Business/Operations/User/UserService.cs
@@ -95,7 +95,7 @@ namespace BankApp.Business.Operations.User
             }
 
             var unProtectedPassword = _dataProtection.Unprotect(userEntity.Password);
-            if (unProtectedPassword != request.password)
+            if (unProtectedPassword != request.Password)
             {
                 return new ServiceMessage<UserInfoDto>()
                 {

--- a/BankApp.WepApi/Controllers/V1/AuthController.cs
+++ b/BankApp.WepApi/Controllers/V1/AuthController.cs
@@ -73,7 +73,7 @@ namespace BankApp.WepApi.Controllers.V1
             var userDto = new LoginRequestDto()
             {
                 Email = request.Email,
-                password = request.Password,
+                Password = request.Password,
             };
 
             var user = await _userService.LoginUserAsync(userDto);


### PR DESCRIPTION
## Summary
- Rename `password` field to `Password` in `LoginRequestDto`
- Update authentication controller and user service to use the new property

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b70895c080832b93d86e9e722b9df2